### PR TITLE
Bug fix

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -11,7 +11,7 @@ An instance of this API (Crobat) is online at the following URL:
 ### Crobat
 Crobat is a command line utility designed to allow easy querying of the Crobat API. To install the client, run the following command: 
 ``` normal
-$ go get github.com/cgboal/sonarsearch/crobat
+$ go get github.com/Cgboal/SonarSearch/crobat
 ```
 
 A Docker container is also available: 


### PR DESCRIPTION
Bug:

```
go: downloading github.com/Cgboal/sonarsearch v0.0.0-20210726140503-95a72ed19f60
go: downloading github.com/Cgboal/sonarsearch/crobat v0.0.0-20210726140503-95a72ed19f60
go get: github.com/Cgboal/sonarsearch/crobat@none updating to
        github.com/Cgboal/sonarsearch/crobat@v0.0.0-20210726140503-95a72ed19f60: parsing go.mod:
        module declares its path as: github.com/Cgboal/SonarSearch/crobat
                but was required as: github.com/Cgboal/sonarsearch/crobat
```