### PR TITLE
Fix go installation URL

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -15,7 +15,7 @@ An instance of this API (Crobat) is online at the following URL:
 ### Crobat
 Crobat is a command line utility designed to allow easy querying of the Crobat API. To install the client, run the following command: 
 ``` normal
-$ go get github.com/cgboal/sonarsearch/cmd/crobat
+$ go install github.com/cgboal/sonarsearch/cmd/crobat@latest
 ```
 
 Below is a full list of command line flags:


### PR DESCRIPTION
`go get` go get cannot used outside of a Go module in Go 1.18 without
disabling. The instruction in README.md does not work and fails for
global CLI installation which is the main use case for this repository.

Read more: https://golang.org/doc/go-get-install-deprecation